### PR TITLE
Validation working with REST Client Reactive

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -21,10 +21,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-arc-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
         <dependency>

--- a/app/src/main/java/com/alesj/qcl/app/QCLAppConfiguration.java
+++ b/app/src/main/java/com/alesj/qcl/app/QCLAppConfiguration.java
@@ -23,6 +23,7 @@ public class QCLAppConfiguration {
         try {
             System.out.println("event = " + service.fact(CatType.sphynx));
         } catch (ConstraintViolationException ignored) {
+            System.out.println(ignored);
         }
     }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,12 +18,26 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client</artifactId>
+            <artifactId>quarkus-rest-client-reactive</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-jackson</artifactId>
+            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+        </dependency>
+        <!-- or you can use quarkus-hibernate-validator here directly, I wasn't sure what you would prefer -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.version>2.5.2.Final</quarkus.version>
         <jandex.version>1.2.1</jandex.version>


### PR DESCRIPTION
So I got it working by using REST Client Reactive... but that means that you would need to switch to RESTEasy Reactive for your REST services. It supports blocking too and it shouldn't be a complicated migration - except if you use advanced features of RESTEasy Classic which might need tuning. I'm sure we would be able to help if you have questions and we aim for RESTEasy Reactive to be a better alternative (it already is in most cases) so we are welcoming feedback.

I don't think we will be able to get the REST Client classic to work as it uses JDK proxies and I don't see a proper way to get them validated with the infrastructure we have.